### PR TITLE
Add API endpoint to validate JWT and check user role

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import { createUserService, getAllUsersService, signInService } from "../services/user.service";
 import { ConflictError, InternalServerError, NotFoundError, UnauthorizedError } from "../utils/errors/app.error";
+import { logger } from "../config/logger.config";
 
 export const signUpHandler = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -13,6 +14,7 @@ export const signUpHandler = async (req: Request, res: Response, next: NextFunct
         });
     } catch (error) {
         if (error instanceof ConflictError) {
+            logger.error(`Error in signUpHandler: ${error.message}`);
             res.status(error.statusCode).json({
                 success: false,
                 message: error.message,
@@ -32,6 +34,7 @@ export const getAllUsersHandler = async (req: Request, res: Response, next: Next
         });
     } catch (error) {
         if (error instanceof InternalServerError) {
+            logger.error(`Error in getAllUsersHandler: ${error.message}`);
             res.status(error.statusCode).json({
                 success: false,
                 message: error.message,
@@ -49,12 +52,12 @@ export const signInHandler = async (req: Request, res: Response, next: NextFunct
         res.status(StatusCodes.OK).json({ token });
     } catch (error) {
         if (error instanceof UnauthorizedError || error instanceof NotFoundError || error instanceof InternalServerError) {
+            logger.error(`Error in signInHanlder: ${error.message}`);
             res.status(error.statusCode).json({
                 success: false,
                 message: error.message,
                 data: {},
             });
         }
-        console.log(error);
     }
 }

--- a/src/dto/user.dto.ts
+++ b/src/dto/user.dto.ts
@@ -1,4 +1,21 @@
+import { JwtPayload } from "jsonwebtoken";
+
 export type signInDto = {
     email: string,
     password: string
+}
+
+export enum RoleType {
+    ADMIN = "admin",
+    USER = "user",
+    MANAGER = "manager"
+}
+
+export type UserHasRoleDto = {
+    token: string,
+    role: RoleType
+}
+
+export interface DecodedToken extends JwtPayload {
+    id: string;
 }

--- a/src/prisma/samples/user.ts
+++ b/src/prisma/samples/user.ts
@@ -1,52 +1,52 @@
 export const users = [
     {
         email: "aarya@example.com",
-        password: "Arya@123",
+        password: "Arya@12345",
         name: "aarya",
     },
     {
         email: "rohan@example.com",
-        password: "Rohan#89",
+        password: "Rohan#8923",
         name: "rohan",
     },
     {
         email: "tanya@example.com",
-        password: "Tanya$77",
+        password: "Tanya$7722",
         name: "tanya",
     },
     {
         email: "dev@example.com",
-        password: "Dev!2024",
+        password: "Dev!2024x9",
         name: "dev",
     },
     {
         email: "isha@example.com",
-        password: "Isha@456",
+        password: "Isha@4567a",
         name: "isha",
     },
     {
         email: "kabir@example.com",
-        password: "Kabir#91",
+        password: "Kabir#91yz",
         name: "kabir",
     },
     {
         email: "neha@example.com",
-        password: "Neha$321",
+        password: "Neha$321xy",
         name: "neha",
     },
     {
         email: "omkar@example.com",
-        password: "Omkar!55",
+        password: "Omkar!5588",
         name: "omkar",
     },
     {
         email: "sanya@example.com",
-        password: "Sanya@99",
+        password: "Sanya@99hh",
         name: "sanya",
     },
     {
         email: "yash@example.com",
-        password: "Yash#100",
+        password: "Yash#100ab",
         name: "yash",
     },
 ];

--- a/src/routers/v1/user.router.ts
+++ b/src/routers/v1/user.router.ts
@@ -1,13 +1,14 @@
 import express from "express";
-import { getAllUsersHandler, signInHandler, signUpHandler } from "../../controllers/user.controller";
+import { getAllUsersHandler, signInHandler, signUpHandler, hasRoleHandler } from "../../controllers/user.controller";
 import { validateRequetBody } from "../../validators";
-import { signInSchema, signUpSchema } from "../../validators/user.validator";
+import { hasRoleSchema, signInSchema, signUpSchema } from "../../validators/user.validator";
 
 const userRouter = express.Router();
 
 userRouter.get('/', getAllUsersHandler);
 userRouter.post('/signup', validateRequetBody(signUpSchema), signUpHandler);
 userRouter.post('/signin', validateRequetBody(signInSchema), signInHandler);
+userRouter.post('/hasrole', validateRequetBody(hasRoleSchema), hasRoleHandler);
 
 
 export default userRouter;

--- a/src/validators/user.validator.ts
+++ b/src/validators/user.validator.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
+import { RoleType } from "../dto/user.dto";
 const strongPasswordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
-;
+
 
 
 export const signUpSchema = z.object({
@@ -24,3 +25,7 @@ export const signInSchema = z.object({
         required_error: "Password is required",
     }).regex(strongPasswordRegex, "Password must be at least 8 characters long, contain at least one uppercase letter, one lowercase letter, one number, and one special character"),
 });
+
+export const hasRoleSchema = z.object({
+    role: z.nativeEnum(RoleType)
+}).strict();

--- a/src/validators/user.validator.ts
+++ b/src/validators/user.validator.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 const strongPasswordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+;
 
 
 export const signUpSchema = z.object({


### PR DESCRIPTION
### Summary

This PR introduces a new API endpoint that accepts a JWT token and a role, validates the token, and checks whether the user has the specified role. The endpoint returns a boolean value indicating the result.

### Changes

- Created an endpoint to:
  - Accept JWT token (via Authorization header or request body)
  - Accept a role as input (body param)
  - Validate the JWT and handle errors for invalid/expired tokens
  - Return a boolean indicating if the user has the specified role
- Added error handling for missing/invalid tokens
- Ensured consistent and secure JWT validation logic

### Acceptance Criteria

- [x] Returns `true` if user has the specified role
- [x] Returns `false` if user does not have the role
- [x] Handles invalid or expired tokens with appropriate error responses

Close #9 